### PR TITLE
Fix: Validate events after running consistency tests

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -56,6 +56,7 @@
     "test:consistency": [
       "php scripts/consistency/prepare.php",
       "paratest tests/Integration --group=parallel --functional --processes 20",
+      "php scripts/consistency/validate-events.php",
       "php scripts/consistency/cleanup.php"
     ],
     "test": [

--- a/scripts/consistency/validate-events.php
+++ b/scripts/consistency/validate-events.php
@@ -1,0 +1,4 @@
+<?php
+
+require __DIR__ . '/../../vendor/autoload.php';
+\Wwwision\DCBEventStoreDoctrine\Tests\Integration\ConcurrencyTest::validateEvents();


### PR DESCRIPTION
This pull request

- [x] validate events after running consistency tests