### PR TITLE
BUGFIX: Fix potential race condition with MySQL, validate events during cleanup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,6 +55,17 @@ jobs:
             health-cmd: 'pg_isready'
             extension: 'pdo_pgsql'
 
+        exclude:
+          - php-version: 'latest'
+            dependencies: 'lowest'
+            database:
+              image: 'postgres:16'
+
+          - php-version: 'latest'
+            dependencies: 'lowest'
+            database:
+              image: 'postgres:17'
+
     services:
       database:
         image: ${{ matrix.database.image }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,7 +56,17 @@ jobs:
             health-cmd: 'pg_isready'
             extension: 'pdo_pgsql'
 
-    continue-on-error: ${{ matrix.php-version == 'latest' && matrix.dependencies == 'lowest' && startsWith(matrix.database.image, 'postgres') }}
+        exclude:
+          # doctrine/dbal 3.x leads to deprecation warnings on PHP 8.5+, so we skip it for now
+          - php-version: 'latest'
+            dependencies: 'lowest'
+            database:
+              image: 'postgres:16'
+
+          - php-version: 'latest'
+            dependencies: 'lowest'
+            database:
+              image: 'postgres:17'
 
     services:
       database:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ permissions:
 
 jobs:
 
-  tests:
+  integration-tests:
     runs-on: ubuntu-latest
 
     strategy:
@@ -106,55 +106,6 @@ jobs:
 
       - name: Set DSN
         run: echo "DCB_TEST_DSN=${{ matrix.database.dsn }}" >> $GITHUB_ENV
-
-      - name: Run integration tests
-        run: composer run-script test:integration
-
-      - name: Run consistency tests
-        run: composer run-script test:consistency
-
-  tests-default-db:
-    runs-on: ubuntu-latest
-
-    strategy:
-      fail-fast: false
-      matrix:
-        php-version:
-          - '8.3'
-          - 'latest'
-        dependencies:
-          - 'highest'
-
-    steps:
-      - name: Setup PHP
-        uses: shivammathur/setup-php@v2
-        with:
-          php-version: ${{ matrix.php-version }}
-          extensions: pdo_sqlite
-
-      - name: Checkout code
-        uses: actions/checkout@v6
-
-      - name: Cache Composer packages
-        id: composer-cache
-        uses: actions/cache@v5
-        with:
-          path: vendor
-          key: ${{ runner.os }}-php${{ matrix.php-version }}-${{ hashFiles('**/composer.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-php${{ matrix.php-version }}-
-
-      - name: Install lowest dependencies
-        if: matrix.dependencies == 'lowest'
-        run: composer update --prefer-dist --prefer-lowest --no-progress
-
-      - name: Install locked dependencies
-        if: matrix.dependencies == 'locked'
-        run: composer install --prefer-dist --no-progress
-
-      - name: Install highest dependencies
-        if: matrix.dependencies == 'highest'
-        run: composer update --prefer-dist --no-progress
 
       - name: Run integration tests
         run: composer run-script test:integration

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,7 @@ permissions:
 jobs:
 
   integration-tests:
+    name: integration-tests (PHP ${{ matrix.php-version }}, ${{ matrix.dependencies }} deps, ${{ matrix.database.image }})
     runs-on: ubuntu-latest
 
     strategy:
@@ -55,16 +56,7 @@ jobs:
             health-cmd: 'pg_isready'
             extension: 'pdo_pgsql'
 
-        exclude:
-          - php-version: 'latest'
-            dependencies: 'lowest'
-            database:
-              image: 'postgres:16'
-
-          - php-version: 'latest'
-            dependencies: 'lowest'
-            database:
-              image: 'postgres:17'
+    continue-on-error: ${{ matrix.php-version == 'latest' && matrix.dependencies == 'lowest' && startsWith(matrix.database.image, 'postgres') }}
 
     services:
       database:

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -16,6 +16,7 @@ jobs:
 
     strategy:
       fail-fast: false
+      max-parallel: 1
       matrix:
         php-version:
           - '8.4'

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -24,13 +24,35 @@ jobs:
           - 'highest'
         database:
           - image: 'mysql:8.0'
+            port: '3307:3306'
+            dsn: 'pdo-mysql://root:password@127.0.0.1:3307/dcb'
             health-cmd: 'mysqladmin ping'
+            extension: 'pdo_mysql'
           - image: 'mysql:8.4'
+            port: '3307:3306'
+            dsn: 'pdo-mysql://root:password@127.0.0.1:3307/dcb'
             health-cmd: 'mysqladmin ping'
+            extension: 'pdo_mysql'
           - image: 'mariadb:10.11'
+            port: '3307:3306'
+            dsn: 'pdo-mysql://root:password@127.0.0.1:3307/dcb'
             health-cmd: 'mariadb-admin ping'
+            extension: 'pdo_mysql'
           - image: 'mariadb:11.4'
+            port: '3307:3306'
+            dsn: 'pdo-mysql://root:password@127.0.0.1:3307/dcb'
             health-cmd: 'mariadb-admin ping'
+            extension: 'pdo_mysql'
+          - image: 'postgres:16'
+            port: '5432:5432'
+            dsn: 'pdo-pgsql://postgres:password@127.0.0.1:5432/dcb'
+            health-cmd: 'pg_isready'
+            extension: 'pdo_pgsql'
+          - image: 'postgres:17'
+            port: '5432:5432'
+            dsn: 'pdo-pgsql://postgres:password@127.0.0.1:5432/dcb'
+            health-cmd: 'pg_isready'
+            extension: 'pdo_pgsql'
 
     services:
       database:
@@ -40,8 +62,10 @@ jobs:
           MYSQL_DATABASE: dcb
           MARIADB_ROOT_PASSWORD: password
           MARIADB_DATABASE: dcb
+          POSTGRES_PASSWORD: password
+          POSTGRES_DB: dcb
         ports:
-          - 3307:3306
+          - ${{ matrix.database.port }}
         options: >-
           --health-cmd="${{ matrix.database.health-cmd }}"
           --health-interval=10s
@@ -53,7 +77,7 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php-version }}
-          extensions: pdo_mysql
+          extensions: ${{ matrix.database.extension }}
 
       - name: Checkout code
         uses: actions/checkout@v6
@@ -80,7 +104,56 @@ jobs:
         run: composer update --prefer-dist --no-progress
 
       - name: Set DSN
-        run: echo "DCB_TEST_DSN=pdo-mysql://root:password@127.0.0.1:3307/dcb" >> $GITHUB_ENV
+        run: echo "DCB_TEST_DSN=${{ matrix.database.dsn }}" >> $GITHUB_ENV
+
+      - name: Run integration tests
+        run: composer run-script test:integration
+
+      - name: Run consistency tests
+        run: composer run-script test:consistency
+
+  tests-sqlite:
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        php-version:
+          - '8.4'
+        dependencies:
+          - 'lowest'
+          - 'highest'
+
+    steps:
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php-version }}
+          extensions: pdo_sqlite
+
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Cache Composer packages
+        id: composer-cache
+        uses: actions/cache@v5
+        with:
+          path: vendor
+          key: ${{ runner.os }}-php-${{ hashFiles('**/composer.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-php-
+
+      - name: Install lowest dependencies
+        if: matrix.dependencies == 'lowest'
+        run: composer update --prefer-dist --prefer-lowest --no-progress
+
+      - name: Install locked dependencies
+        if: matrix.dependencies == 'locked'
+        run: composer install --prefer-dist --no-progress
+
+      - name: Install highest dependencies
+        if: matrix.dependencies == 'highest'
+        run: composer update --prefer-dist --no-progress
 
       - name: Run integration tests
         run: composer run-script test:integration

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -121,7 +121,6 @@ jobs:
         php-version:
           - '8.4'
         dependencies:
-          - 'lowest'
           - 'highest'
 
     steps:

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -20,6 +20,7 @@ jobs:
       matrix:
         php-version:
           - '8.5'
+          - '8.4'
         dependencies:
           - 'highest'
         database:

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -16,7 +16,7 @@ jobs:
 
     strategy:
       fail-fast: false
-      max-parallel: 1
+      max-parallel: 2
       matrix:
         php-version:
           - '8.5'
@@ -36,15 +36,6 @@ jobs:
         ports:
           - 3306/tcp
         options: --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=3
-      postgres:
-        image: postgres:latest
-        env:
-          POSTGRES_USER: root
-          POSTGRES_PASSWORD: password
-          POSTGRES_DB: dcb
-        ports:
-          - 5432/tcp
-        options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 3
 
     steps:
       - name: Setup PHP

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -10,91 +10,6 @@ permissions:
   contents: read
 
 jobs:
-  coding-standards:
-    runs-on: ubuntu-latest
-
-    strategy:
-      matrix:
-        php-version:
-          - '8.3'
-        dependencies:
-          - 'highest'
-
-    steps:
-      - name: Setup PHP
-        uses: shivammathur/setup-php@v2
-        with:
-          php-version: ${{ matrix.php-version }}
-
-      - name: Checkout code
-        uses: actions/checkout@v6
-
-      - name: Cache Composer packages
-        id: composer-cache
-        uses: actions/cache@v5
-        with:
-          path: vendor
-          key: ${{ runner.os }}-php-${{ hashFiles('**/composer.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-php-
-
-      - name: Install lowest dependencies
-        if: matrix.dependencies == 'lowest'
-        run: composer update --prefer-dist --prefer-lowest --no-progress
-
-      - name: Install locked dependencies
-        if: matrix.dependencies == 'locked'
-        run: composer install --prefer-dist --no-progress
-
-      - name: Install highest dependencies
-        if: matrix.dependencies == 'highest'
-        run: composer update --prefer-dist --no-progress
-
-      - name: Check coding standards
-        run: composer run-script test:cs
-
-  static-code-analysis:
-    runs-on: ubuntu-latest
-
-    strategy:
-      matrix:
-        php-version:
-          - '8.3'
-        dependencies:
-          - 'highest'
-
-    steps:
-      - name: Setup PHP
-        uses: shivammathur/setup-php@v2
-        with:
-          php-version: ${{ matrix.php-version }}
-
-      - name: Checkout code
-        uses: actions/checkout@v6
-
-      - name: Cache Composer packages
-        id: composer-cache
-        uses: actions/cache@v5
-        with:
-          path: vendor
-          key: ${{ runner.os }}-php-${{ hashFiles('**/composer.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-php-
-
-      - name: Install lowest dependencies
-        if: matrix.dependencies == 'lowest'
-        run: composer update --prefer-dist --prefer-lowest --no-progress
-
-      - name: Install locked dependencies
-        if: matrix.dependencies == 'locked'
-        run: composer install --prefer-dist --no-progress
-
-      - name: Install highest dependencies
-        if: matrix.dependencies == 'highest'
-        run: composer update --prefer-dist --no-progress
-
-      - name: Run static code analysis
-        run: composer run-script test:phpstan
 
   tests:
     runs-on: ubuntu-latest
@@ -103,15 +18,11 @@ jobs:
       fail-fast: false
       matrix:
         php-version:
-          - '8.3'
           - '8.4'
-          - '8.5'
         dependencies:
           - 'highest'
         database:
           - 'mysql'
-          - 'postgres'
-          - 'sqlite'
 
     services:
       mysql:

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -19,7 +19,6 @@ jobs:
       max-parallel: 1
       matrix:
         php-version:
-          - '8.4'
           - '8.5'
         dependencies:
           - 'highest'

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -112,7 +112,7 @@ jobs:
       - name: Run consistency tests
         run: composer run-script test:consistency
 
-  tests-sqlite:
+  tests-default-db:
     runs-on: ubuntu-latest
 
     strategy:

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -16,11 +16,11 @@ jobs:
 
     strategy:
       fail-fast: false
-      max-parallel: 2
+      max-parallel: 1
       matrix:
         php-version:
-          - '8.5'
           - '8.4'
+          - '8.5'
         dependencies:
           - 'highest'
         database:

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -18,7 +18,8 @@ jobs:
       fail-fast: false
       matrix:
         php-version:
-          - '8.4'
+          - '8.3'
+          - 'latest'
         dependencies:
           - 'lowest'
           - 'highest'
@@ -87,9 +88,9 @@ jobs:
         uses: actions/cache@v5
         with:
           path: vendor
-          key: ${{ runner.os }}-php-${{ hashFiles('**/composer.lock') }}
+          key: ${{ runner.os }}-php${{ matrix.php-version }}-${{ hashFiles('**/composer.lock') }}
           restore-keys: |
-            ${{ runner.os }}-php-
+            ${{ runner.os }}-php${{ matrix.php-version }}-
 
       - name: Install lowest dependencies
         if: matrix.dependencies == 'lowest'
@@ -119,7 +120,8 @@ jobs:
       fail-fast: false
       matrix:
         php-version:
-          - '8.4'
+          - '8.3'
+          - 'latest'
         dependencies:
           - 'highest'
 
@@ -138,9 +140,9 @@ jobs:
         uses: actions/cache@v5
         with:
           path: vendor
-          key: ${{ runner.os }}-php-${{ hashFiles('**/composer.lock') }}
+          key: ${{ runner.os }}-php${{ matrix.php-version }}-${{ hashFiles('**/composer.lock') }}
           restore-keys: |
-            ${{ runner.os }}-php-
+            ${{ runner.os }}-php${{ matrix.php-version }}-
 
       - name: Install lowest dependencies
         if: matrix.dependencies == 'lowest'
@@ -159,3 +161,41 @@ jobs:
 
       - name: Run consistency tests
         run: composer run-script test:consistency
+
+  static-analysis:
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        php-version:
+          - '8.3'
+          - 'latest'
+
+    steps:
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php-version }}
+          extensions: pdo_mysql, pdo_pgsql, pdo_sqlite
+
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Cache Composer packages
+        id: composer-cache
+        uses: actions/cache@v5
+        with:
+          path: vendor
+          key: ${{ runner.os }}-php${{ matrix.php-version }}-${{ hashFiles('**/composer.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-php${{ matrix.php-version }}-
+
+      - name: Install highest dependencies
+        run: composer update --prefer-dist --no-progress
+
+      - name: Run PHPStan
+        run: composer run-script test:phpstan
+
+      - name: Run code style check
+        run: composer run-script test:cs

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -33,7 +33,7 @@ jobs:
           MYSQL_ROOT_PASSWORD: password
           MYSQL_DATABASE: dcb
         ports:
-          - 3306/tcp
+          - 3307:3306
         options: --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=3
 
     steps:
@@ -41,7 +41,7 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php-version }}
-          extensions: pdo_mysql, pdo_sqlite, pdo_pgsql
+          extensions: pdo_mysql
 
       - name: Checkout code
         uses: actions/checkout@v6
@@ -70,7 +70,7 @@ jobs:
       - name: Set DSN
         run: |
           case "${{ matrix.database }}" in
-            mysql) echo "DCB_TEST_DSN=pdo-mysql://root:password@127.0.0.1:${{ job.services.mysql.ports['3306'] }}/dcb" >> $GITHUB_ENV ;;
+            mysql) echo "DCB_TEST_DSN=pdo-mysql://root:password@127.0.0.1:3307/dcb" >> $GITHUB_ENV ;;
             postgres) echo "DCB_TEST_DSN=pdo-pgsql://root:password@127.0.0.1:${{ job.services.postgres.ports['5432'] }}/dcb" >> $GITHUB_ENV ;;
             sqlite) echo "DCB_TEST_DSN=pdo-sqlite:///events.sqlite" >> $GITHUB_ENV ;;
           esac

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -16,9 +16,9 @@ jobs:
 
     strategy:
       fail-fast: false
-      max-parallel: 2
       matrix:
         php-version:
+          - '8.3'
           - '8.4'
           - '8.5'
         dependencies:

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -18,24 +18,35 @@ jobs:
       fail-fast: false
       matrix:
         php-version:
-          - '8.3'
           - '8.4'
-          - '8.5'
         dependencies:
+          - 'lowest'
           - 'highest'
         database:
-          - 'mysql'
+          - image: 'mysql:8.0'
+            health-cmd: 'mysqladmin ping'
+          - image: 'mysql:8.4'
+            health-cmd: 'mysqladmin ping'
+          - image: 'mariadb:10.11'
+            health-cmd: 'mariadb-admin ping'
+          - image: 'mariadb:11.4'
+            health-cmd: 'mariadb-admin ping'
 
     services:
-      mysql:
-        image: mysql:latest
+      database:
+        image: ${{ matrix.database.image }}
         env:
-          MYSQL_ALLOW_EMPTY_PASSWORD: false
           MYSQL_ROOT_PASSWORD: password
           MYSQL_DATABASE: dcb
+          MARIADB_ROOT_PASSWORD: password
+          MARIADB_DATABASE: dcb
         ports:
           - 3307:3306
-        options: --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=3
+        options: >-
+          --health-cmd="${{ matrix.database.health-cmd }}"
+          --health-interval=10s
+          --health-timeout=5s
+          --health-retries=3
 
     steps:
       - name: Setup PHP
@@ -69,12 +80,7 @@ jobs:
         run: composer update --prefer-dist --no-progress
 
       - name: Set DSN
-        run: |
-          case "${{ matrix.database }}" in
-            mysql) echo "DCB_TEST_DSN=pdo-mysql://root:password@127.0.0.1:3307/dcb" >> $GITHUB_ENV ;;
-            postgres) echo "DCB_TEST_DSN=pdo-pgsql://root:password@127.0.0.1:${{ job.services.postgres.ports['5432'] }}/dcb" >> $GITHUB_ENV ;;
-            sqlite) echo "DCB_TEST_DSN=pdo-sqlite:///events.sqlite" >> $GITHUB_ENV ;;
-          esac
+        run: echo "DCB_TEST_DSN=pdo-mysql://root:password@127.0.0.1:3307/dcb" >> $GITHUB_ENV
 
       - name: Run integration tests
         run: composer run-script test:integration

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -16,7 +16,6 @@ jobs:
 
     strategy:
       fail-fast: false
-      max-parallel: 1
       matrix:
         php-version:
           - '8.4'

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -19,7 +19,6 @@ jobs:
       max-parallel: 1
       matrix:
         php-version:
-          - '8.5'
           - '8.4'
         dependencies:
           - 'highest'

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -19,8 +19,8 @@ jobs:
       max-parallel: 1
       matrix:
         php-version:
-          - '8.4'
           - '8.5'
+          - '8.4'
         dependencies:
           - 'highest'
         database:

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -19,6 +19,7 @@ jobs:
       matrix:
         php-version:
           - '8.4'
+          - '8.5'
         dependencies:
           - 'highest'
         database:

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -16,10 +16,11 @@ jobs:
 
     strategy:
       fail-fast: false
-      max-parallel: 1
+      max-parallel: 2
       matrix:
         php-version:
           - '8.4'
+          - '8.5'
         dependencies:
           - 'highest'
         database:

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
     "ramsey/uuid": "^4.7",
     "psr/clock": "^1",
     "webmozart/assert": "^1.11",
-    "doctrine/dbal": "^3.6",
+    "doctrine/dbal": "^4",
     "wwwision/dcb-eventstore": "^5"
   },
   "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
     "ramsey/uuid": "^4.7",
     "psr/clock": "^1",
     "webmozart/assert": "^1.11",
-    "doctrine/dbal": "^4",
+    "doctrine/dbal": "^3.6",
     "wwwision/dcb-eventstore": "^5"
   },
   "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
     "ramsey/uuid": "^4.7",
     "psr/clock": "^1",
     "webmozart/assert": "^1.11",
-    "doctrine/dbal": "3.6.0",
+    "doctrine/dbal": "^4",
     "wwwision/dcb-eventstore": "^5"
   },
   "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
     "ramsey/uuid": "^4.7",
     "psr/clock": "^1",
     "webmozart/assert": "^1.11",
-    "doctrine/dbal": "3.8.4",
+    "doctrine/dbal": "3.8.2",
     "wwwision/dcb-eventstore": "^5"
   },
   "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -51,7 +51,7 @@
     "test:cs:fix": "vendor/bin/php-cs-fixer fix",
     "test:integration": [
       "echo $DCB_TEST_DSN",
-      "phpunit tests/Integration --exclude-group=parallel --exclude-group=feature_liveStream --exclude-group=feature_appendConditionWithoutMatchingEvent"
+      "phpunit tests/Integration --exclude-group=parallel --exclude-group=validate --exclude-group=feature_liveStream --exclude-group=feature_appendConditionWithoutMatchingEvent"
     ],
     "test:consistency": [
       "php scripts/consistency/prepare.php",

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
     "ramsey/uuid": "^4.7",
     "psr/clock": "^1",
     "webmozart/assert": "^1.11",
-    "doctrine/dbal": "3.9.5",
+    "doctrine/dbal": "3.7.3",
     "wwwision/dcb-eventstore": "^5"
   },
   "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
     "ramsey/uuid": "^4.7",
     "psr/clock": "^1",
     "webmozart/assert": "^1.11",
-    "doctrine/dbal": "3.8.0",
+    "doctrine/dbal": "3.8.4",
     "wwwision/dcb-eventstore": "^5"
   },
   "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
     "ramsey/uuid": "^4.7",
     "psr/clock": "^1",
     "webmozart/assert": "^1.11",
-    "doctrine/dbal": "3.7.3",
+    "doctrine/dbal": "3.6.0",
     "wwwision/dcb-eventstore": "^5"
   },
   "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
     "ramsey/uuid": "^4.7",
     "psr/clock": "^1",
     "webmozart/assert": "^1.11",
-    "doctrine/dbal": "3.7.4",
+    "doctrine/dbal": "3.7.3",
     "wwwision/dcb-eventstore": "^5"
   },
   "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -31,8 +31,8 @@
     "roave/security-advisories": "dev-latest",
     "phpstan/phpstan": "^2",
     "friendsofphp/php-cs-fixer": "^3.88",
-    "phpunit/phpunit": "^12",
-    "brianium/paratest": "^7"
+    "phpunit/phpunit": "^12.1",
+    "brianium/paratest": "^7.9"
   },
   "autoload": {
     "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
     "ramsey/uuid": "^4.7",
     "psr/clock": "^1",
     "webmozart/assert": "^1.11",
-    "doctrine/dbal": "3.7.3",
+    "doctrine/dbal": "3.8.7",
     "wwwision/dcb-eventstore": "^5"
   },
   "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
     "ramsey/uuid": "^4.7",
     "psr/clock": "^1",
     "webmozart/assert": "^1.11",
-    "doctrine/dbal": "^4",
+    "doctrine/dbal": "^3",
     "wwwision/dcb-eventstore": "^5"
   },
   "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
     "ramsey/uuid": "^4.7",
     "psr/clock": "^1",
     "webmozart/assert": "^1.11",
-    "doctrine/dbal": "4.0.0",
+    "doctrine/dbal": "3.9.5",
     "wwwision/dcb-eventstore": "^5"
   },
   "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
     "ramsey/uuid": "^4.7",
     "psr/clock": "^1",
     "webmozart/assert": "^1.11",
-    "doctrine/dbal": "^3",
+    "doctrine/dbal": "^4",
     "wwwision/dcb-eventstore": "^5"
   },
   "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
     "roave/security-advisories": "dev-latest",
     "phpstan/phpstan": "^2",
     "friendsofphp/php-cs-fixer": "^3.88",
-    "phpunit/phpunit": "^11",
+    "phpunit/phpunit": "^12",
     "brianium/paratest": "^7"
   },
   "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
     "ramsey/uuid": "^4.7",
     "psr/clock": "^1",
     "webmozart/assert": "^1.11",
-    "doctrine/dbal": "3.8.0",
+    "doctrine/dbal": "3.7.4",
     "wwwision/dcb-eventstore": "^5"
   },
   "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
     "ramsey/uuid": "^4.7",
     "psr/clock": "^1",
     "webmozart/assert": "^1.11",
-    "doctrine/dbal": "3.8.0",
+    "doctrine/dbal": "3.8.1",
     "wwwision/dcb-eventstore": "^5"
   },
   "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,7 @@
     "phpstan/phpstan": "^2",
     "friendsofphp/php-cs-fixer": "^3.88",
     "phpunit/phpunit": "^12.1",
-    "brianium/paratest": "^7.9"
+    "brianium/paratest": "^7.10.3"
   },
   "autoload": {
     "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
     "ramsey/uuid": "^4.7",
     "psr/clock": "^1",
     "webmozart/assert": "^1.11",
-    "doctrine/dbal": "^4",
+    "doctrine/dbal": "4.0.0",
     "wwwision/dcb-eventstore": "^5"
   },
   "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -56,6 +56,7 @@
     "test:consistency": [
       "php scripts/consistency/prepare.php",
       "paratest tests/Integration --group=parallel --functional --processes 20",
+      "phpunit tests/Integration --group=validate",
       "php scripts/consistency/cleanup.php"
     ],
     "test": [

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
     "ramsey/uuid": "^4.7",
     "psr/clock": "^1",
     "webmozart/assert": "^1.11",
-    "doctrine/dbal": "3.8.1",
+    "doctrine/dbal": "3.8.0",
     "wwwision/dcb-eventstore": "^5"
   },
   "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
     "ramsey/uuid": "^4.7",
     "psr/clock": "^1",
     "webmozart/assert": "^1.11",
-    "doctrine/dbal": "3.8.2",
+    "doctrine/dbal": "3.8.1",
     "wwwision/dcb-eventstore": "^5"
   },
   "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
     "psr/clock": "^1",
     "webmozart/assert": "^1.11",
     "doctrine/dbal": "^3.6 || ^4",
-    "wwwision/dcb-eventstore": "^5"
+    "wwwision/dcb-eventstore": "^5.0.1"
   },
   "require-dev": {
     "roave/security-advisories": "dev-latest",

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
     "ramsey/uuid": "^4.7",
     "psr/clock": "^1",
     "webmozart/assert": "^1.11",
-    "doctrine/dbal": "3.8.7",
+    "doctrine/dbal": "3.8.0",
     "wwwision/dcb-eventstore": "^5"
   },
   "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
     "ramsey/uuid": "^4.7",
     "psr/clock": "^1",
     "webmozart/assert": "^1.11",
-    "doctrine/dbal": "^4",
+    "doctrine/dbal": "^3.6 || ^4",
     "wwwision/dcb-eventstore": "^5"
   },
   "require-dev": {

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -2,3 +2,4 @@ parameters:
   level: max
   paths:
     - src
+    - tests

--- a/scripts/consistency/cleanup.php
+++ b/scripts/consistency/cleanup.php
@@ -1,3 +1,4 @@
 <?php
+
 require __DIR__ . '/../../vendor/autoload.php';
 \Wwwision\DCBEventStoreDoctrine\Tests\Integration\ConcurrencyTest::cleanup();

--- a/scripts/consistency/cleanup.php
+++ b/scripts/consistency/cleanup.php
@@ -1,4 +1,13 @@
 <?php
 
 require __DIR__ . '/../../vendor/autoload.php';
+$caughtException = null;
+try {
+    \Wwwision\DCBEventStoreDoctrine\Tests\Integration\ConcurrencyTest::validateEvents();
+} catch (Throwable $e) {
+    $caughtException = $e;
+}
 \Wwwision\DCBEventStoreDoctrine\Tests\Integration\ConcurrencyTest::cleanup();
+if ($caughtException !== null) {
+    throw $caughtException;
+}

--- a/scripts/consistency/cleanup.php
+++ b/scripts/consistency/cleanup.php
@@ -1,13 +1,3 @@
 <?php
-
 require __DIR__ . '/../../vendor/autoload.php';
-$caughtException = null;
-try {
-    \Wwwision\DCBEventStoreDoctrine\Tests\Integration\ConcurrencyTest::validateEvents();
-} catch (Throwable $e) {
-    $caughtException = $e;
-}
 \Wwwision\DCBEventStoreDoctrine\Tests\Integration\ConcurrencyTest::cleanup();
-if ($caughtException !== null) {
-    throw $caughtException;
-}

--- a/src/DoctrineEventStore.php
+++ b/src/DoctrineEventStore.php
@@ -254,13 +254,9 @@ final class DoctrineEventStore implements EventStore
     private function applyDcbQueryItemConstraints(QueryBuilder $queryBuilder, QueryItem $dcbQueryItem): void
     {
         if ($dcbQueryItem->eventTypes !== null) {
-            $placeholders = [];
-            foreach ($dcbQueryItem->eventTypes->toStringArray() as $eventType) {
-                $paramName = $this->config->createUniqueParameterName();
-                $placeholders[] = ':' . $paramName;
-                $queryBuilder->setParameter($paramName, $eventType);
-            }
-            $queryBuilder->andWhere('type IN (' . implode(', ', $placeholders) . ')');
+            $eventTypesParameterName = $this->config->createUniqueParameterName();
+            $queryBuilder->andWhere("type IN (:$eventTypesParameterName)");
+            $queryBuilder->setParameter($eventTypesParameterName, $dcbQueryItem->eventTypes->toStringArray(), ArrayParameterType::STRING);
         }
         if ($dcbQueryItem->tags !== null) {
             $tagsParameterName = $this->config->createUniqueParameterName();

--- a/src/DoctrineEventStore.php
+++ b/src/DoctrineEventStore.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Wwwision\DCBEventStoreDoctrine;
 
 use DateTimeImmutable;
+use Doctrine\DBAL\ArrayParameterType;
 use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Exception as DbalException;
 use Doctrine\DBAL\Exception\DeadlockException;

--- a/src/DoctrineEventStore.php
+++ b/src/DoctrineEventStore.php
@@ -216,7 +216,7 @@ final class DoctrineEventStore implements EventStore
                     // guarantee mutual exclusion during the check-then-insert operation.
                     $mysqlAdvisoryLockName = 'dcb_' . $this->config->eventTableName;
                     $lockAcquired = $this->config->connection->fetchOne('SELECT GET_LOCK(?, 30)', [$mysqlAdvisoryLockName]);
-                    if ((int) $lockAcquired !== 1) {
+                    if (!is_numeric($lockAcquired) || (int) $lockAcquired !== 1) {
                         throw new RuntimeException(sprintf('Failed to acquire advisory lock "%s" for event store append', $mysqlAdvisoryLockName));
                     }
                 }

--- a/src/DoctrineEventStore.php
+++ b/src/DoctrineEventStore.php
@@ -196,7 +196,7 @@ final class DoctrineEventStore implements EventStore
 
     /**
      * @param array<int<0, max>|string, mixed> $parameters
-     * @param array<int<0, max>|string, ParameterType|Type|string> $parameterTypes
+     * @param array<int<0, max>|string, ArrayParameterType|ParameterType|Type|string> $parameterTypes
      */
     private function commitStatement(string $statement, array $parameters, array $parameterTypes): int
     {
@@ -205,14 +205,20 @@ final class DoctrineEventStore implements EventStore
         $retryAttempt = 0;
         while (true) {
             $transactionStarted = false;
+            $mysqlAdvisoryLockName = null;
             try {
                 if ($this->config->isPostgreSQL()) {
                     $this->config->connection->executeStatement('BEGIN ISOLATION LEVEL SERIALIZABLE');
                     $transactionStarted = true;
                 } elseif ($this->config->isMySQL()) {
-                    $this->config->connection->executeStatement('SET TRANSACTION ISOLATION LEVEL SERIALIZABLE');
-                    $this->config->connection->executeStatement('START TRANSACTION');
-                    $transactionStarted = true;
+                    // MySQL's SERIALIZABLE isolation does not acquire gap locks for complex INSERT...WHERE NOT EXISTS
+                    // queries with derived subqueries, allowing phantom reads. We use an advisory lock instead to
+                    // guarantee mutual exclusion during the check-then-insert operation.
+                    $mysqlAdvisoryLockName = 'dcb_' . $this->config->eventTableName;
+                    $lockAcquired = $this->config->connection->fetchOne('SELECT GET_LOCK(?, 30)', [$mysqlAdvisoryLockName]);
+                    if ($lockAcquired !== '1') {
+                        throw new RuntimeException(sprintf('Failed to acquire advisory lock "%s" for event store append', $mysqlAdvisoryLockName));
+                    }
                 }
                 $affectedRows = (int) $this->config->connection->executeStatement($statement, $parameters, $parameterTypes);
                 if ($transactionStarted) {
@@ -239,6 +245,13 @@ final class DoctrineEventStore implements EventStore
             } finally {
                 if ($transactionStarted) {
                     $this->config->connection->executeStatement('ROLLBACK');
+                }
+                if ($mysqlAdvisoryLockName !== null) {
+                    try {
+                        $this->config->connection->fetchOne('SELECT RELEASE_LOCK(?)', [$mysqlAdvisoryLockName]);
+                    } catch (\Throwable) {
+                        // ignore – connection may already be closed
+                    }
                 }
             }
         }

--- a/src/DoctrineEventStore.php
+++ b/src/DoctrineEventStore.php
@@ -227,6 +227,14 @@ final class DoctrineEventStore implements EventStore
                 $retryAttempt++;
                 $retryWaitInterval *= 2;
             } catch (DbalException $e) {
+                // MariaDB error 1467 ("Failed to read auto-increment value from storage engine") is a transient
+                // concurrency failure under SERIALIZABLE isolation — treat it like a deadlock and retry
+                if ((int) $e->getCode() === 1467 && $retryAttempt < $maxRetryAttempts) {
+                    usleep((int) ($retryWaitInterval * 1E6));
+                    $retryAttempt++;
+                    $retryWaitInterval *= 2;
+                    continue;
+                }
                 throw new RuntimeException(sprintf('Failed to commit events (error code: %d): %s', (int) $e->getCode(), $e->getMessage()), 1685956215, $e);
             } finally {
                 if ($transactionStarted) {

--- a/src/DoctrineEventStore.php
+++ b/src/DoctrineEventStore.php
@@ -216,7 +216,7 @@ final class DoctrineEventStore implements EventStore
                     // guarantee mutual exclusion during the check-then-insert operation.
                     $mysqlAdvisoryLockName = 'dcb_' . $this->config->eventTableName;
                     $lockAcquired = $this->config->connection->fetchOne('SELECT GET_LOCK(?, 30)', [$mysqlAdvisoryLockName]);
-                    if ($lockAcquired !== '1') {
+                    if ((int) $lockAcquired !== 1) {
                         throw new RuntimeException(sprintf('Failed to acquire advisory lock "%s" for event store append', $mysqlAdvisoryLockName));
                     }
                 }

--- a/src/DoctrineEventStore.php
+++ b/src/DoctrineEventStore.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Wwwision\DCBEventStoreDoctrine;
 
 use DateTimeImmutable;
-use Doctrine\DBAL\ArrayParameterType;
 use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Exception as DbalException;
 use Doctrine\DBAL\Exception\DeadlockException;
@@ -196,7 +195,7 @@ final class DoctrineEventStore implements EventStore
 
     /**
      * @param array<int<0, max>|string, mixed> $parameters
-     * @param array<int<0, max>|string, ArrayParameterType|ParameterType|Type|string> $parameterTypes
+     * @param array<int<0, max>|string, ParameterType|Type|string> $parameterTypes
      */
     private function commitStatement(string $statement, array $parameters, array $parameterTypes): int
     {
@@ -255,9 +254,13 @@ final class DoctrineEventStore implements EventStore
     private function applyDcbQueryItemConstraints(QueryBuilder $queryBuilder, QueryItem $dcbQueryItem): void
     {
         if ($dcbQueryItem->eventTypes !== null) {
-            $eventTypesParameterName = $this->config->createUniqueParameterName();
-            $queryBuilder->andWhere("type IN (:$eventTypesParameterName)");
-            $queryBuilder->setParameter($eventTypesParameterName, $dcbQueryItem->eventTypes->toStringArray(), ArrayParameterType::STRING);
+            $placeholders = [];
+            foreach ($dcbQueryItem->eventTypes->toStringArray() as $eventType) {
+                $paramName = $this->config->createUniqueParameterName();
+                $placeholders[] = ':' . $paramName;
+                $queryBuilder->setParameter($paramName, $eventType);
+            }
+            $queryBuilder->andWhere('type IN (' . implode(', ', $placeholders) . ')');
         }
         if ($dcbQueryItem->tags !== null) {
             $tagsParameterName = $this->config->createUniqueParameterName();

--- a/src/DoctrineEventStore.php
+++ b/src/DoctrineEventStore.php
@@ -174,19 +174,19 @@ final class DoctrineEventStore implements EventStore
         $unionSelects = implode(' UNION ALL ', $selects);
 
         $statement = "INSERT INTO {$this->config->eventTableName} (type, data, metadata, tags, recorded_at) SELECT * FROM ( $unionSelects ) new_events";
-        $queryBuilder = null;
+        $parameterTypes = [];
         if ($condition !== null) {
-            $queryBuilder = $this->config->connection->createQueryBuilder()->select('events.sequence_number')->from($this->config->eventTableName, 'events')->orderBy('events.sequence_number', 'DESC')->setMaxResults(1);
-            $this->addDcbQueryConstraints($queryBuilder, $condition->failIfEventsMatch);
-            $parameters = [...$parameters, ...$queryBuilder->getParameters()];
-            if ($condition->after === null) {
-                $statement .= ' WHERE NOT EXISTS (' . $queryBuilder->getSQL() . ')';
-            } else {
-                $statement .= ' WHERE (' . $queryBuilder->getSQL() . ') = :highestSequenceNumber';
-                $parameters['highestSequenceNumber'] = $condition->after->value;
+            $conditionQueryBuilder = $this->config->connection->createQueryBuilder()->select('1')->from($this->config->eventTableName, 'events');
+            $this->addDcbQueryConstraints($conditionQueryBuilder, $condition->failIfEventsMatch);
+            if ($condition->after !== null) {
+                $conditionQueryBuilder->andWhere('events.sequence_number > :highestSequenceNumber');
+                $conditionQueryBuilder->setParameter('highestSequenceNumber', $condition->after->value);
             }
+            $parameters = [...$parameters, ...$conditionQueryBuilder->getParameters()];
+            $parameterTypes = $conditionQueryBuilder->getParameterTypes();
+            $statement .= ' WHERE NOT EXISTS (' . $conditionQueryBuilder->getSQL() . ')';
         }
-        $affectedRows = $this->commitStatement($statement, $parameters, $queryBuilder?->getParameterTypes() ?? []);
+        $affectedRows = $this->commitStatement($statement, $parameters, $parameterTypes);
         if ($affectedRows === 0 && $condition !== null) {
             throw $condition->after === null ? ConditionalAppendFailed::becauseMatchingEventsExist() : ConditionalAppendFailed::becauseMatchingEventsExistAfterSequencePosition($condition->after);
         }
@@ -204,12 +204,18 @@ final class DoctrineEventStore implements EventStore
         $maxRetryAttempts = 10;
         $retryAttempt = 0;
         while (true) {
+            $transactionStarted = false;
             try {
                 if ($this->config->isPostgreSQL()) {
                     $this->config->connection->executeStatement('BEGIN ISOLATION LEVEL SERIALIZABLE');
+                    $transactionStarted = true;
+                } elseif ($this->config->isMySQL()) {
+                    $this->config->connection->executeStatement('SET TRANSACTION ISOLATION LEVEL SERIALIZABLE');
+                    $this->config->connection->executeStatement('START TRANSACTION');
+                    $transactionStarted = true;
                 }
                 $affectedRows = (int) $this->config->connection->executeStatement($statement, $parameters, $parameterTypes);
-                if ($this->config->isPostgreSQL()) {
+                if ($transactionStarted) {
                     $this->config->connection->executeStatement('COMMIT');
                 }
                 return $affectedRows;
@@ -223,7 +229,7 @@ final class DoctrineEventStore implements EventStore
             } catch (DbalException $e) {
                 throw new RuntimeException(sprintf('Failed to commit events (error code: %d): %s', (int) $e->getCode(), $e->getMessage()), 1685956215, $e);
             } finally {
-                if ($this->config->isPostgreSQL()) {
+                if ($transactionStarted) {
                     $this->config->connection->executeStatement('ROLLBACK');
                 }
             }

--- a/src/DoctrineEventStoreConfiguration.php
+++ b/src/DoctrineEventStoreConfiguration.php
@@ -7,6 +7,7 @@ namespace Wwwision\DCBEventStoreDoctrine;
 use DateTimeImmutable;
 use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Exception as DbalException;
+use Doctrine\DBAL\Platforms\AbstractMySQLPlatform;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Platforms\PostgreSQLPlatform;
 use Doctrine\DBAL\Platforms\SQLitePlatform;
@@ -67,5 +68,10 @@ final class DoctrineEventStoreConfiguration
     public function isSQLite(): bool
     {
         return $this->platform instanceof SQLitePlatform;
+    }
+
+    public function isMySQL(): bool
+    {
+        return $this->platform instanceof AbstractMySQLPlatform;
     }
 }

--- a/src/DoctrineEventStoreConfiguration.php
+++ b/src/DoctrineEventStoreConfiguration.php
@@ -10,7 +10,7 @@ use Doctrine\DBAL\Exception as DbalException;
 use Doctrine\DBAL\Platforms\AbstractMySQLPlatform;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Platforms\PostgreSQLPlatform;
-use Doctrine\DBAL\Platforms\SqlitePlatform;
+use Doctrine\DBAL\Platforms\SQLitePlatform;
 use Psr\Clock\ClockInterface;
 use RuntimeException;
 

--- a/src/DoctrineEventStoreConfiguration.php
+++ b/src/DoctrineEventStoreConfiguration.php
@@ -10,7 +10,7 @@ use Doctrine\DBAL\Exception as DbalException;
 use Doctrine\DBAL\Platforms\AbstractMySQLPlatform;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Platforms\PostgreSQLPlatform;
-use Doctrine\DBAL\Platforms\SQLitePlatform;
+use Doctrine\DBAL\Platforms\SqlitePlatform;
 use Psr\Clock\ClockInterface;
 use RuntimeException;
 

--- a/tests/Integration/ConcurrencyTest.php
+++ b/tests/Integration/ConcurrencyTest.php
@@ -32,15 +32,7 @@ final class ConcurrencyTest extends EventStoreConcurrencyTestBase
         $connection = self::connection();
         $eventStore = self::createEventStore();
         $eventStore->setup();
-        if ($connection->getDatabasePlatform() instanceof PostgreSQLPlatform) {
-            $connection->executeStatement('TRUNCATE TABLE ' . self::eventTableName() . ' RESTART IDENTITY');
-        } elseif ($connection->getDatabasePlatform() instanceof SqlitePlatform) {
-            /** @noinspection SqlWithoutWhere */
-            $connection->executeStatement('DELETE FROM ' . self::eventTableName());
-            $connection->executeStatement('DELETE FROM sqlite_sequence WHERE name =\'' . self::eventTableName() . '\'');
-        } else {
-            $connection->executeStatement('TRUNCATE TABLE ' . self::eventTableName());
-        }
+        self::cleanup();
         echo PHP_EOL . 'Prepared tables for ' . $connection->getDatabasePlatform()::class . PHP_EOL;
     }
 

--- a/tests/Integration/ConcurrencyTest.php
+++ b/tests/Integration/ConcurrencyTest.php
@@ -12,6 +12,7 @@ use Doctrine\DBAL\Platforms\SqlitePlatform;
 use Doctrine\DBAL\Schema\DefaultSchemaManagerFactory;
 use Doctrine\DBAL\Tools\DsnParser;
 use PHPUnit\Framework\Attributes\CoversNothing;
+use PHPUnit\Framework\Attributes\Group;
 use Wwwision\DCBEventStore\EventStore;
 use Wwwision\DCBEventStore\Tests\Integration\EventStoreConcurrencyTestBase;
 use Wwwision\DCBEventStoreDoctrine\DoctrineEventStore;
@@ -74,6 +75,12 @@ final class ConcurrencyTest extends EventStoreConcurrencyTestBase
     private static function eventTableName(): string
     {
         return 'dcb_events_test';
+    }
+
+    #[Group('validate')]
+    public function test_validate_events(): void
+    {
+        self::validateEvents();
     }
 
 }

--- a/tests/Integration/ConcurrencyTest.php
+++ b/tests/Integration/ConcurrencyTest.php
@@ -8,7 +8,7 @@ use Doctrine\DBAL\Configuration;
 use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\DriverManager;
 use Doctrine\DBAL\Platforms\PostgreSQLPlatform;
-use Doctrine\DBAL\Platforms\SqlitePlatform;
+use Doctrine\DBAL\Platforms\SQLitePlatform;
 use Doctrine\DBAL\Schema\DefaultSchemaManagerFactory;
 use Doctrine\DBAL\Tools\DsnParser;
 use PHPUnit\Framework\Attributes\CoversNothing;
@@ -32,6 +32,9 @@ final class ConcurrencyTest extends EventStoreConcurrencyTestBase
     {
         $connection = self::connection();
         $eventStore = self::createEventStore();
+        if (!$eventStore instanceof DoctrineEventStore) {
+            self::fail('Expected ' . DoctrineEventStore::class . ', got ' . $eventStore::class);
+        }
         $eventStore->setup();
         self::cleanup();
         echo PHP_EOL . 'Prepared tables for ' . $connection->getDatabasePlatform()::class . PHP_EOL;
@@ -40,7 +43,7 @@ final class ConcurrencyTest extends EventStoreConcurrencyTestBase
     public static function cleanup(): void
     {
         $connection = self::connection();
-        if ($connection->getDatabasePlatform() instanceof SqlitePlatform) {
+        if ($connection->getDatabasePlatform() instanceof SQLitePlatform) {
             $connection->executeStatement('DELETE FROM ' . self::eventTableName());
             $connection->executeStatement('UPDATE SQLITE_SEQUENCE SET SEQ=0 WHERE NAME="' . self::eventTableName() . '"');
         } elseif ($connection->getDatabasePlatform() instanceof PostgreSQLPlatform) {

--- a/tests/Integration/DoctrineEventStoreTest.php
+++ b/tests/Integration/DoctrineEventStoreTest.php
@@ -7,7 +7,7 @@ namespace Wwwision\DCBEventStoreDoctrine\Tests\Integration;
 use Doctrine\DBAL\Configuration;
 use Doctrine\DBAL\DriverManager;
 use Doctrine\DBAL\Platforms\PostgreSQLPlatform;
-use Doctrine\DBAL\Platforms\SqlitePlatform;
+use Doctrine\DBAL\Platforms\SQLitePlatform;
 use Doctrine\DBAL\Schema\DefaultSchemaManagerFactory;
 use Doctrine\DBAL\Tools\DsnParser;
 use PHPUnit\Framework\Attributes\CoversClass;
@@ -38,7 +38,7 @@ final class DoctrineEventStoreTest extends EventStoreTestBase
             ->withClock($this->getTestClock());
         $eventStore = new DoctrineEventStore($eventStoreConfiguration);
         $eventStore->setup();
-        if ($connection->getDatabasePlatform() instanceof SqlitePlatform) {
+        if ($connection->getDatabasePlatform() instanceof SQLitePlatform) {
             $connection->executeStatement('DELETE FROM ' . $eventTableName);
             $connection->executeStatement('UPDATE SQLITE_SEQUENCE SET SEQ=0 WHERE NAME="' . $eventTableName . '"');
         } elseif ($connection->getDatabasePlatform() instanceof PostgreSQLPlatform) {


### PR DESCRIPTION
This pull request makes significant improvements to the project's CI workflow, database concurrency handling, and dependency management. The main changes include replacing the old GitHub Actions workflow with a more comprehensive and flexible CI pipeline, enhancing concurrency safety for MySQL and MariaDB in the event store, updating dependencies for better compatibility, and improving test coverage and organization.

**CI/CD and Workflow Improvements:**

* Replaces `.github/workflows/php.yml` with a new `.github/workflows/ci.yml` that introduces a matrix build for multiple PHP versions, dependency sets, and database engines (MySQL, MariaDB, PostgreSQL), and adds explicit integration, consistency, static analysis, and code style jobs. This provides broader and more reliable CI coverage. [[1]](diffhunk://#diff-a73bb6555480a5ee79ae276a3f5d71a08fa316e09a4a8da7b643cf1e92c97df9L1-L179) [[2]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fR1-R165)

**Database Concurrency and Platform Handling:**

* Improves concurrency safety for MySQL by introducing advisory locks during conditional appends to prevent phantom reads, and adds retry logic for known transient MariaDB errors. Also adds an `isMySQL()` helper to the configuration. [[1]](diffhunk://#diff-a1a89c066416272be8fac55a2ecfde3cad9c9ca5dea5d21eac24df539f33bd52L177-R189) [[2]](diffhunk://#diff-a1a89c066416272be8fac55a2ecfde3cad9c9ca5dea5d21eac24df539f33bd52R207-R224) [[3]](diffhunk://#diff-a1a89c066416272be8fac55a2ecfde3cad9c9ca5dea5d21eac24df539f33bd52R236-R255) [[4]](diffhunk://#diff-aac6ba61e953ad3907d22336a4946dc1cd9eae63609191373e72029ba941aeddR10) [[5]](diffhunk://#diff-aac6ba61e953ad3907d22336a4946dc1cd9eae63609191373e72029ba941aeddR72-R76)
* Updates SQL platform class references from `SqlitePlatform` to the correct `SQLitePlatform` in tests for consistency and compatibility. [[1]](diffhunk://#diff-eab018fb2c0e93acd83c2b0a2fc310e72326bff912087428d91aa36b68cdca13L11-R15) [[2]](diffhunk://#diff-eab018fb2c0e93acd83c2b0a2fc310e72326bff912087428d91aa36b68cdca13L34-R46) [[3]](diffhunk://#diff-73bb53e769f2c805a5470b32e871fbc7c9c081e6ec119395ad1289536b1bdedfL10-R10) [[4]](diffhunk://#diff-73bb53e769f2c805a5470b32e871fbc7c9c081e6ec119395ad1289536b1bdedfL41-R41)

**Dependency and Composer Script Updates:**

* Updates `composer.json` to allow `doctrine/dbal` v3.6+ (for compatibility with PHP 8.3+) and bumps other dependencies (`wwwision/dcb-eventstore`, `phpunit/phpunit`, `brianium/paratest`) to newer versions.
* Refines Composer test scripts to better separate validation and consistency checks, and to ensure all relevant test groups are run.

**Testing Improvements:**

* Adds a dedicated `validate` test group for event validation in `ConcurrencyTest`, and ensures it is run as part of the test suite. [[1]](diffhunk://#diff-eab018fb2c0e93acd83c2b0a2fc310e72326bff912087428d91aa36b68cdca13R83-R88) [[2]](diffhunk://#diff-d2ab9925cad7eac58e0ff4cc0d251a937ecf49e4b6bf57f8b95aab76648a9d34L54-R59)
* Expands static analysis to include the `tests` directory in PHPStan configuration.

These changes collectively modernize the CI process, increase reliability of database operations under concurrency, and improve maintainability and compatibility of the codebase.