### PR TITLE
BUGFIX: Fix potential race condition with MySQL

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
     "roave/security-advisories": "dev-latest",
     "phpstan/phpstan": "^2",
     "squizlabs/php_codesniffer": "^4.0.x-dev",
-    "phpunit/phpunit": "^11",
+    "phpunit/phpunit": "^12",
     "brianium/paratest": "^7"
   },
   "autoload": {
@@ -51,12 +51,12 @@
     "test:cs:fix": "phpcbf --colors src",
     "test:integration": [
       "echo $DCB_TEST_DSN",
-      "phpunit tests/Integration --exclude-group=parallel --exclude-group=feature_liveStream --exclude-group=feature_appendConditionWithoutMatchingEvent"
+      "phpunit tests/Integration --exclude-group=parallel --exclude-group=validate --exclude-group=feature_liveStream --exclude-group=feature_appendConditionWithoutMatchingEvent"
     ],
     "test:consistency": [
       "php scripts/consistency/prepare.php",
       "paratest tests/Integration --group=parallel --functional --processes 20",
-      "vendor/bin/phpunit --colors --filter validateEvents tests/Integration/ConcurrencyTest.php",
+      "phpunit tests/Integration --group=validate",
       "php scripts/consistency/cleanup.php"
     ],
     "test": [

--- a/src/DoctrineEventStore.php
+++ b/src/DoctrineEventStore.php
@@ -173,19 +173,23 @@ final class DoctrineEventStore implements EventStore, Setupable
         $unionSelects = implode(' UNION ALL ', $selects);
 
         $statement = "INSERT INTO {$this->config->eventTableName} (type, data, metadata, tags, recorded_at) SELECT * FROM ( $unionSelects ) new_events";
-        $queryBuilder = null;
+        $parameterTypes = [];
         if (!$condition->expectedHighestSequenceNumber->isAny()) {
-            $queryBuilder = $this->config->connection->createQueryBuilder()->select('events.sequence_number')->from($this->config->eventTableName, 'events')->orderBy('events.sequence_number', 'DESC')->setMaxResults(1);
-            $this->addStreamQueryConstraints($queryBuilder, $condition->query);
-            $parameters = [...$parameters, ...$queryBuilder->getParameters()];
-            if ($condition->expectedHighestSequenceNumber->isNone()) {
-                $statement .= ' WHERE NOT EXISTS (' . $queryBuilder->getSQL() . ')';
-            } else {
-                $statement .= ' WHERE (' . $queryBuilder->getSQL() . ') = :highestSequenceNumber';
-                $parameters['highestSequenceNumber'] = $condition->expectedHighestSequenceNumber->extractSequenceNumber()->value;
+            // Forward NOT EXISTS scan: InnoDB acquires a gap lock on (highestSequenceNumber, supremum]
+            // preventing concurrent inserts of matching events until this transaction commits.
+            $conditionQueryBuilder = $this->config->connection->createQueryBuilder()
+                ->select('1')
+                ->from($this->config->eventTableName, 'events');
+            $this->addStreamQueryConstraints($conditionQueryBuilder, $condition->query);
+            if (!$condition->expectedHighestSequenceNumber->isNone()) {
+                $conditionQueryBuilder->andWhere('events.sequence_number > :highestSequenceNumber');
+                $conditionQueryBuilder->setParameter('highestSequenceNumber', $condition->expectedHighestSequenceNumber->extractSequenceNumber()->value);
             }
+            $parameters = [...$parameters, ...$conditionQueryBuilder->getParameters()];
+            $parameterTypes = $conditionQueryBuilder->getParameterTypes();
+            $statement .= ' WHERE NOT EXISTS (' . $conditionQueryBuilder->getSQL() . ')';
         }
-        $affectedRows = $this->commitStatement($statement, $parameters, $queryBuilder?->getParameterTypes() ?? []);
+        $affectedRows = $this->commitStatement($statement, $parameters, $parameterTypes);
         if ($affectedRows === 0 && !$condition->expectedHighestSequenceNumber->isAny()) {
             throw $condition->expectedHighestSequenceNumber->isNone() ? ConditionalAppendFailed::becauseNoEventWhereExpected() : ConditionalAppendFailed::becauseHighestExpectedSequenceNumberDoesNotMatch($condition->expectedHighestSequenceNumber);
         }
@@ -203,12 +207,18 @@ final class DoctrineEventStore implements EventStore, Setupable
         $maxRetryAttempts = 10;
         $retryAttempt = 0;
         while (true) {
+            $transactionStarted = false;
             try {
                 if ($this->config->isPostgreSQL()) {
                     $this->config->connection->executeStatement('BEGIN ISOLATION LEVEL SERIALIZABLE');
+                    $transactionStarted = true;
+                } elseif ($this->config->isMySQL()) {
+                    $this->config->connection->executeStatement('SET TRANSACTION ISOLATION LEVEL SERIALIZABLE');
+                    $this->config->connection->executeStatement('START TRANSACTION');
+                    $transactionStarted = true;
                 }
                 $affectedRows = (int)$this->config->connection->executeStatement($statement, $parameters, $parameterTypes);
-                if ($this->config->isPostgreSQL()) {
+                if ($transactionStarted) {
                     $this->config->connection->executeStatement('COMMIT');
                 }
                 return $affectedRows;
@@ -222,7 +232,7 @@ final class DoctrineEventStore implements EventStore, Setupable
             } catch (DbalException $e) {
                 throw new RuntimeException(sprintf('Failed to commit events (error code: %d): %s', (int)$e->getCode(), $e->getMessage()), 1685956215, $e);
             } finally {
-                if ($this->config->isPostgreSQL()) {
+                if ($transactionStarted) {
                     $this->config->connection->executeStatement('ROLLBACK');
                 }
             }

--- a/src/DoctrineEventStoreConfiguration.php
+++ b/src/DoctrineEventStoreConfiguration.php
@@ -6,6 +6,7 @@ namespace Wwwision\DCBEventStoreDoctrine;
 
 use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Exception as DbalException;
+use Doctrine\DBAL\Platforms\AbstractMySQLPlatform;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Platforms\PostgreSQLPlatform;
 use Doctrine\DBAL\Platforms\SqlitePlatform;
@@ -62,5 +63,10 @@ final class DoctrineEventStoreConfiguration
     public function isSQLite(): bool
     {
         return $this->platform instanceof SqlitePlatform;
+    }
+
+    public function isMySQL(): bool
+    {
+        return $this->platform instanceof AbstractMySQLPlatform;
     }
 }

--- a/src/DoctrineEventStream.php
+++ b/src/DoctrineEventStream.php
@@ -44,6 +44,11 @@ final class DoctrineEventStream implements EventStream
     private static function databaseRowToEventEnvelope(array $row): EventEnvelope
     {
         Assert::numeric($row['sequence_number']);
+        Assert::string($row['recorded_at']);
+        Assert::string($row['type']);
+        Assert::string($row['data']);
+        Assert::string($row['tags']);
+        Assert::nullOrString($row['metadata']);
         $recordedAt = DateTimeImmutable::createFromFormat('Y-m-d H:i:s', $row['recorded_at']);
         Assert::isInstanceOf($recordedAt, DateTimeImmutable::class);
         return new EventEnvelope(

--- a/tests/Integration/ConcurrencyTest.php
+++ b/tests/Integration/ConcurrencyTest.php
@@ -11,6 +11,7 @@ use Doctrine\DBAL\Platforms\SqlitePlatform;
 use Doctrine\DBAL\Schema\DefaultSchemaManagerFactory;
 use Doctrine\DBAL\Tools\DsnParser;
 use PHPUnit\Framework\Attributes\CoversNothing;
+use PHPUnit\Framework\Attributes\Group;
 use Wwwision\DCBEventStore\EventStore;
 use Wwwision\DCBEventStore\Tests\Integration\EventStoreConcurrencyTestBase;
 use Wwwision\DCBEventStoreDoctrine\DoctrineEventStore;
@@ -30,15 +31,7 @@ final class ConcurrencyTest extends EventStoreConcurrencyTestBase
         $connection = self::connection();
         $eventStore = self::createEventStore();
         $eventStore->setup();
-        if ($connection->getDatabasePlatform() instanceof PostgreSQLPlatform) {
-            $connection->executeStatement('TRUNCATE TABLE ' . self::eventTableName() . ' RESTART IDENTITY');
-        } elseif ($connection->getDatabasePlatform() instanceof SqlitePlatform) {
-            /** @noinspection SqlWithoutWhere */
-            $connection->executeStatement('DELETE FROM ' . self::eventTableName());
-            $connection->executeStatement('DELETE FROM sqlite_sequence WHERE name =\'' . self::eventTableName() . '\'');
-        } else {
-            $connection->executeStatement('TRUNCATE TABLE ' . self::eventTableName());
-        }
+        self::cleanup();
         echo PHP_EOL . 'Prepared tables for ' . $connection->getDatabasePlatform()::class . PHP_EOL;
     }
 
@@ -80,6 +73,12 @@ final class ConcurrencyTest extends EventStoreConcurrencyTestBase
     private static function eventTableName(): string
     {
         return 'dcb_events_test';
+    }
+
+    #[Group('validate')]
+    public function test_validate_events(): void
+    {
+        self::validateEvents();
     }
 
 }


### PR DESCRIPTION
This pull request introduces several improvements and fixes related to database compatibility, transaction handling, and test configuration. The most significant changes include improved transaction isolation for MySQL, enhanced assertion checks, and updates to test groupings and dependencies.

**Database transaction handling and compatibility:**

* Improved transaction handling for MySQL: Added explicit support for serializable transactions in MySQL by setting the isolation level and starting transactions, ensuring consistent behavior with PostgreSQL and better concurrency control. The transaction is now properly tracked with a `$transactionStarted` flag for both commit and rollback operations. (`src/DoctrineEventStore.php`, `src/DoctrineEventStoreConfiguration.php`) [[1]](diffhunk://#diff-a1a89c066416272be8fac55a2ecfde3cad9c9ca5dea5d21eac24df539f33bd52R210-R221) [[2]](diffhunk://#diff-a1a89c066416272be8fac55a2ecfde3cad9c9ca5dea5d21eac24df539f33bd52L225-R235) [[3]](diffhunk://#diff-aac6ba61e953ad3907d22336a4946dc1cd9eae63609191373e72029ba941aeddR9) [[4]](diffhunk://#diff-aac6ba61e953ad3907d22336a4946dc1cd9eae63609191373e72029ba941aeddR67-R71)
* Refactored conditional append logic: Simplified and clarified the logic for conditional appends, especially around sequence number checks and parameter handling, to improve correctness and maintainability. (`src/DoctrineEventStore.php`)

**Testing and assertions:**

* Updated PHPUnit dependency to version 12 and adjusted test scripts to use a new `validate` group for better test organization and compatibility. (`composer.json`) [[1]](diffhunk://#diff-d2ab9925cad7eac58e0ff4cc0d251a937ecf49e4b6bf57f8b95aab76648a9d34L34-R34) [[2]](diffhunk://#diff-d2ab9925cad7eac58e0ff4cc0d251a937ecf49e4b6bf57f8b95aab76648a9d34L54-R59)
* Added more detailed assertion checks in `databaseRowToEventEnvelope` to ensure type safety for event data fields. (`src/DoctrineEventStream.php`)
* Improved integration test setup and validation: Refactored table cleanup logic and added a dedicated test method for event validation with proper grouping. (`tests/Integration/ConcurrencyTest.php`) [[1]](diffhunk://#diff-eab018fb2c0e93acd83c2b0a2fc310e72326bff912087428d91aa36b68cdca13R14) [[2]](diffhunk://#diff-eab018fb2c0e93acd83c2b0a2fc310e72326bff912087428d91aa36b68cdca13L33-R34) [[3]](diffhunk://#diff-eab018fb2c0e93acd83c2b0a2fc310e72326bff912087428d91aa36b68cdca13R78-R83)