### PR TITLE
BUGFIX: Fix potential race condition with MySQL

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -2,9 +2,9 @@ name: CI
 
 on:
   push:
-    branches: [ "main" ]
+    branches: [ "main", "5.0" ]
   pull_request:
-    branches: [ "main" ]
+    branches: [ "main", "5.0" ]
 
 permissions:
   contents: read

--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
     "roave/security-advisories": "dev-latest",
     "phpstan/phpstan": "^2",
     "friendsofphp/php-cs-fixer": "^3.88",
-    "phpunit/phpunit": "^11",
+    "phpunit/phpunit": "^12",
     "brianium/paratest": "^7"
   },
   "autoload": {
@@ -51,11 +51,12 @@
     "test:cs:fix": "vendor/bin/php-cs-fixer fix",
     "test:integration": [
       "echo $DCB_TEST_DSN",
-      "phpunit tests/Integration --exclude-group=parallel --exclude-group=feature_liveStream --exclude-group=feature_appendConditionWithoutMatchingEvent"
+      "phpunit tests/Integration --exclude-group=parallel --exclude-group=validate --exclude-group=feature_liveStream --exclude-group=feature_appendConditionWithoutMatchingEvent"
     ],
     "test:consistency": [
       "php scripts/consistency/prepare.php",
       "paratest tests/Integration --group=parallel --functional --processes 20",
+      "phpunit tests/Integration --group=validate",
       "php scripts/consistency/cleanup.php"
     ],
     "test": [

--- a/src/DoctrineEventStore.php
+++ b/src/DoctrineEventStore.php
@@ -179,19 +179,19 @@ final class DoctrineEventStore implements EventStore
         $unionSelects = implode(' UNION ALL ', $selects);
 
         $statement = "INSERT INTO {$this->config->eventTableName} (type, data, metadata, tags, recorded_at) SELECT * FROM ( $unionSelects ) new_events";
-        $queryBuilder = null;
+        $parameterTypes = [];
         if ($condition !== null) {
-            $queryBuilder = $this->config->connection->createQueryBuilder()->select('events.sequence_number')->from($this->config->eventTableName, 'events')->orderBy('events.sequence_number', 'DESC')->setMaxResults(1);
-            $this->addDcbQueryConstraints($queryBuilder, $condition->failIfEventsMatch);
-            $parameters = [...$parameters, ...$queryBuilder->getParameters()];
-            if ($condition->after === null) {
-                $statement .= ' WHERE NOT EXISTS (' . $queryBuilder->getSQL() . ')';
-            } else {
-                $statement .= ' WHERE (' . $queryBuilder->getSQL() . ') = :highestSequenceNumber';
-                $parameters['highestSequenceNumber'] = $condition->after->value;
+            $conditionQueryBuilder = $this->config->connection->createQueryBuilder()->select('1')->from($this->config->eventTableName, 'events');
+            $this->addDcbQueryConstraints($conditionQueryBuilder, $condition->failIfEventsMatch);
+            if ($condition->after !== null) {
+                $conditionQueryBuilder->andWhere('events.sequence_number > :highestSequenceNumber');
+                $conditionQueryBuilder->setParameter('highestSequenceNumber', $condition->after->value);
             }
+            $parameters = [...$parameters, ...$conditionQueryBuilder->getParameters()];
+            $parameterTypes = $conditionQueryBuilder->getParameterTypes();
+            $statement .= ' WHERE NOT EXISTS (' . $conditionQueryBuilder->getSQL() . ')';
         }
-        $affectedRows = $this->commitStatement($statement, $parameters, $queryBuilder?->getParameterTypes() ?? []);
+        $affectedRows = $this->commitStatement($statement, $parameters, $parameterTypes);
         if ($affectedRows === 0 && $condition !== null) {
             throw $condition->after === null ? ConditionalAppendFailed::becauseMatchingEventsExist() : ConditionalAppendFailed::becauseMatchingEventsExistAfterSequencePosition($condition->after);
         }
@@ -209,12 +209,18 @@ final class DoctrineEventStore implements EventStore
         $maxRetryAttempts = 10;
         $retryAttempt = 0;
         while (true) {
+            $transactionStarted = false;
             try {
                 if ($this->config->isPostgreSQL()) {
                     $this->config->connection->executeStatement('BEGIN ISOLATION LEVEL SERIALIZABLE');
+                    $transactionStarted = true;
+                } elseif ($this->config->isMySQL()) {
+                    $this->config->connection->executeStatement('SET TRANSACTION ISOLATION LEVEL SERIALIZABLE');
+                    $this->config->connection->executeStatement('START TRANSACTION');
+                    $transactionStarted = true;
                 }
                 $affectedRows = (int) $this->config->connection->executeStatement($statement, $parameters, $parameterTypes);
-                if ($this->config->isPostgreSQL()) {
+                if ($transactionStarted) {
                     $this->config->connection->executeStatement('COMMIT');
                 }
                 return $affectedRows;
@@ -228,7 +234,7 @@ final class DoctrineEventStore implements EventStore
             } catch (DbalException $e) {
                 throw new RuntimeException(sprintf('Failed to commit events (error code: %d): %s', (int) $e->getCode(), $e->getMessage()), 1685956215, $e);
             } finally {
-                if ($this->config->isPostgreSQL()) {
+                if ($transactionStarted) {
                     $this->config->connection->executeStatement('ROLLBACK');
                 }
             }

--- a/src/DoctrineEventStoreConfiguration.php
+++ b/src/DoctrineEventStoreConfiguration.php
@@ -7,6 +7,7 @@ namespace Wwwision\DCBEventStoreDoctrine;
 use DateTimeImmutable;
 use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Exception as DbalException;
+use Doctrine\DBAL\Platforms\AbstractMySQLPlatform;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Platforms\PostgreSQLPlatform;
 use Doctrine\DBAL\Platforms\SqlitePlatform;
@@ -67,5 +68,10 @@ final class DoctrineEventStoreConfiguration
     public function isSQLite(): bool
     {
         return $this->platform instanceof SqlitePlatform;
+    }
+
+    public function isMySQL(): bool
+    {
+        return $this->platform instanceof AbstractMySQLPlatform;
     }
 }

--- a/tests/Integration/ConcurrencyTest.php
+++ b/tests/Integration/ConcurrencyTest.php
@@ -12,6 +12,7 @@ use Doctrine\DBAL\Platforms\SqlitePlatform;
 use Doctrine\DBAL\Schema\DefaultSchemaManagerFactory;
 use Doctrine\DBAL\Tools\DsnParser;
 use PHPUnit\Framework\Attributes\CoversNothing;
+use PHPUnit\Framework\Attributes\Group;
 use Wwwision\DCBEventStore\EventStore;
 use Wwwision\DCBEventStore\Tests\Integration\EventStoreConcurrencyTestBase;
 use Wwwision\DCBEventStoreDoctrine\DoctrineEventStore;
@@ -32,15 +33,7 @@ final class ConcurrencyTest extends EventStoreConcurrencyTestBase
         $connection = self::connection();
         $eventStore = self::createEventStore();
         $eventStore->setup();
-        if ($connection->getDatabasePlatform() instanceof PostgreSQLPlatform) {
-            $connection->executeStatement('TRUNCATE TABLE ' . self::eventTableName() . ' RESTART IDENTITY');
-        } elseif ($connection->getDatabasePlatform() instanceof SqlitePlatform) {
-            /** @noinspection SqlWithoutWhere */
-            $connection->executeStatement('DELETE FROM ' . self::eventTableName());
-            $connection->executeStatement('DELETE FROM sqlite_sequence WHERE name =\'' . self::eventTableName() . '\'');
-        } else {
-            $connection->executeStatement('TRUNCATE TABLE ' . self::eventTableName());
-        }
+        self::cleanup();
         echo PHP_EOL . 'Prepared tables for ' . $connection->getDatabasePlatform()::class . PHP_EOL;
     }
 
@@ -82,6 +75,12 @@ final class ConcurrencyTest extends EventStoreConcurrencyTestBase
     private static function eventTableName(): string
     {
         return 'dcb_events_test';
+    }
+
+    #[Group('validate')]
+    public function test_validate_events(): void
+    {
+        self::validateEvents();
     }
 
 }


### PR DESCRIPTION
This pull request introduces several improvements and fixes related to database compatibility, transaction handling, and test configuration. The most significant changes include improved transaction isolation for MySQL, enhanced assertion checks, and updates to test groupings and dependencies.

**Database transaction handling and compatibility:**

* Improved transaction handling for MySQL: Added explicit support for serializable transactions in MySQL by setting the isolation level and starting transactions, ensuring consistent behavior with PostgreSQL and better concurrency control. The transaction is now properly tracked with a `$transactionStarted` flag for both commit and rollback operations. (`src/DoctrineEventStore.php`, `src/DoctrineEventStoreConfiguration.php`)
* Refactored conditional append logic: Simplified and clarified the logic for conditional appends, especially around sequence number checks and parameter handling, to improve correctness and maintainability. (`src/DoctrineEventStore.php`)

**Testing and assertions:**

* Updated PHPUnit dependency to version 12 and adjusted test scripts to use a new `validate` group for better test organization and compatibility.
* Improved integration test setup and validation: Refactored table cleanup logic and added a dedicated test method for event validation with proper grouping.